### PR TITLE
registro de envío cotizado (HU3)

### DIFF
--- a/frontend-quotation/src/services/shipmentService.ts
+++ b/frontend-quotation/src/services/shipmentService.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import type { RegisterShipmentDTO, ShipmentResponseDTO } from '../types';
+
+const API_URL = 'http://localhost:3000';
+
+export async function registerShipment(data: RegisterShipmentDTO): Promise<ShipmentResponseDTO> {
+  const token = localStorage.getItem('token');
+  const response = await axios.post(`${API_URL}/shipment`, data, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return response.data;
+}

--- a/frontend-quotation/src/types/index.ts
+++ b/frontend-quotation/src/types/index.ts
@@ -10,3 +10,28 @@ export interface QuoteRequestDTO {
 export interface QuoteResponseDTO {
   priceCents: number;
 }
+
+
+export interface RegisterShipmentDTO {
+  origin: string;
+  destination: string;
+  weightKg: number;
+  lengthCm: number;
+  widthCm: number;
+  heightCm: number;
+  quotedPriceCents: number;
+}
+
+export interface ShipmentResponseDTO {
+  id: number;
+  origin: string;
+  destination: string;
+  weightKg: number;
+  lengthCm: number;
+  widthCm: number;
+  heightCm: number;
+  chargeableWeight: number;
+  quotedPriceCents: number;
+  status: string;
+  createdAt: string;
+}


### PR DESCRIPTION
implements the functionality corresponding to the User Story **HU3 - Quoted Shipment Order Creation**.

It allows the user, after quoting a shipment, to confirm and register the shipment in the system.

---

### Changes made

- ✅ The quotation form (HU2) is reused to capture the package data.
- 📌 The quoted value (`priceCents`) is stored after calculation.
- 🆕 The `Confirm Shipment` button that appears after quoting is added.
- A `POST /shipment` request is made sending the `RegisterShipmentDTO`.
- ✅ Authentication via JWT is included.
- 📩 A success alert is displayed with the registered shipment ID.

---

### Modified files

- QuotePage.tsx`: logic and form UI extended to include confirmation.
- `shipmentService.ts`: new service file for registration
- `types/index.ts`: definition of DTOs `RegisterShipmentDTO` and `ShipmentResponseDTO`.

---

### Checklist

- x] The “Confirm Shipment” button appears only after a valid quotation.
- x] The registered shipment includes the quoted price.
- x] Shipment ID is displayed to the user
- x] Authentication with JWT is maintained
- x] No errors or regression in HU1 and HU2

